### PR TITLE
hfxk: enable

### DIFF
--- a/src/hfx_energy_potential.F
+++ b/src/hfx_energy_potential.F
@@ -158,13 +158,13 @@ CONTAINS
          i_list_kl, i_set_list_ij, i_set_list_ij_start, i_set_list_ij_stop, i_set_list_kl, &
          i_set_list_kl_start, i_set_list_kl_stop, i_thread, iatom, iatom_block, iatom_end, &
          iatom_start, ikind, img, iset, iw, j, jatom, jatom_block, jatom_end, jatom_start, jkind, &
-         jset, katom, katom_block, katom_end, katom_start, kind_kind_idx, kkind, kset, l_max
-      INTEGER :: latom, latom_block, latom_end, latom_start, lkind, lset, ma, max_pgf, max_set, &
-         mb, my_bin_id, my_bin_size, my_task_counter, my_thread_id, n_threads, natom, nbidx, &
-         nbits, ncoa, ncob, ncos_max, nints, nkimages, nkind, nneighbors, nseta, nsetb, nsgf_max, &
-         pa, sgfa, shm_number_of_p_entries, shm_task_counter, shm_total_bins, sphi_a_u1, &
-         sphi_a_u2, sphi_a_u3, sphi_b_u1, sphi_b_u2, sphi_b_u3, sphi_c_u1, sphi_c_u2, sphi_c_u3, &
-         sphi_d_u1, sphi_d_u2, sphi_d_u3, swap_id, tmp_i4, unit_id
+         jset, katom, katom_block, katom_end, katom_start, kind_kind_idx, kkind, kp_idx_q
+      INTEGER :: kp_idx_t, kset, l_max, latom, latom_block, latom_end, latom_start, lkind, lset, &
+         ma, max_pgf, max_set, mb, my_bin_id, my_bin_size, my_task_counter, my_thread_id, &
+         n_threads, natom, nbidx, nbits, ncoa, ncob, ncos_max, nints, nkimages, nkind, nneighbors, &
+         nseta, nsetb, nsgf_max, pa, sgfa, shm_number_of_p_entries, shm_task_counter, &
+         shm_total_bins, sphi_a_u1, sphi_a_u2, sphi_a_u3, sphi_b_u1, sphi_b_u2, sphi_b_u3, &
+         sphi_c_u1, sphi_c_u2, sphi_c_u3, sphi_d_u1, sphi_d_u2, sphi_d_u3, swap_id, tmp_i4, unit_id
       INTEGER(int_8) :: atom_block, counter, estimate_to_store_int, max_val_memory, &
          mb_size_buffers, mb_size_p, mem_compression_counter, mem_compression_counter_disk, &
          mem_eris, mem_eris_disk, mem_max_val, memsize_after, memsize_before, my_istart, &
@@ -360,7 +360,8 @@ CONTAINS
       ! actual usage can vary, though, since storage is per-thread
       do_disk_storage = shm_master_x_data%memory_parameter%do_disk_storage
 
-      do_dynamic_load_balancing = (n_threads > 1) .AND. (.NOT. do_disk_storage)
+      ! KP support messes up the performance model, do round-robin instead
+      do_dynamic_load_balancing = (n_threads > 1) .AND. (.NOT. do_disk_storage) .AND. (nkimages == 1)
 
       ! If we have a hybrid functional, we may need only a fraction of exact exchange
       ! Initialize a prefactor depending on the fraction and the number of spins
@@ -706,6 +707,7 @@ CONTAINS
 !$OMP                                  para_env,&
 !$OMP                                  my_geo_change,&
 !$OMP                                  irep,&
+!$OMP                                  kpoints,&
 !$OMP                                  dft_control,&
 !$OMP                                  is_unrestricted,&
 !$OMP                                  ncoset,&
@@ -785,7 +787,7 @@ CONTAINS
 !$OMP         sphi_c_ext_set,sphi_d_ext_set,pmax_entry,log10_pmax,nints,estimate_to_store_int,&
 !$OMP         spherical_estimate,nbits,buffer_left,buffer_start,buffer_size,max_contraction_val,tmp_r_1,tmp_r_2,&
 !$OMP         tmp_screen_pgf1,tmp_screen_pgf2,cartesian_estimate,bintime_stop,iw,i,j,tmp_i4,&
-!$OMP         bin,eps_scaling_str,eps_schwarz_min_str,nbidx,iatom_block,jatom_block) &
+!$OMP         bin,eps_scaling_str,eps_schwarz_min_str,nbidx,kp_idx_q,kp_idx_t,iatom_block,jatom_block) &
 !$OMP REDUCTION(+: shm_neris_total,shm_neris_onthefly,shm_neris_incore,shm_neris_disk,&
 !$OMP              shm_nprim_ints,shm_stor_counter_integrals,shm_stor_count_int_disk,&
 !$OMP              shm_stor_count_max_val,shm_mem_compression_counter) &
@@ -1154,8 +1156,14 @@ CONTAINS
                   symm_fac = 0.5_dp
                   IF (iatom == jatom) symm_fac = symm_fac*2.0_dp
                   IF (katom == latom) symm_fac = symm_fac*2.0_dp
-                  IF (iatom == katom .AND. jatom == latom .AND. iatom /= jatom .AND. katom /= latom) symm_fac = symm_fac*2.0_dp
-                  IF (iatom == katom .AND. iatom == jatom .AND. katom == latom) symm_fac = symm_fac*2.0_dp
+
+                  IF (nkimages == 1) THEN
+                     IF (iatom == katom .AND. jatom == latom .AND. iatom /= jatom .AND. katom /= latom) symm_fac = symm_fac*2.0_dp
+                     IF (iatom == katom .AND. iatom == jatom .AND. katom == latom) symm_fac = symm_fac*2.0_dp
+                  ELSE
+                     IF (iatom + jatom == katom + latom) symm_fac = symm_fac*2.0_dp
+                  END IF
+
                   symm_fac = 1.0_dp/symm_fac
 
                   lc_max => basis_parameter(kkind)%lmax
@@ -1361,232 +1369,268 @@ CONTAINS
                         sphi_c_ext_set => sphi_c_ext(:, :, :, kset)
                         sphi_d_ext_set => sphi_d_ext(:, :, :, lset)
 
-                        !! Calculate integrals if we run out of buffer or the geometry did change
-                        IF (my_geo_change .OR. buffer_overflow) THEN
-                           max_contraction_val = max_contraction(iset, iatom)* &
-                                                 max_contraction(jset, jatom)* &
-                                                 max_contraction(kset, katom)* &
-                                                 max_contraction(lset, latom)*pmax_entry
-                           tmp_R_1 => radii_pgf(:, :, jset, iset, jkind, ikind)
-                           tmp_R_2 => radii_pgf(:, :, lset, kset, lkind, kkind)
-                           tmp_screen_pgf1 => screen_coeffs_pgf(:, :, jset, iset, jkind, ikind)
-                           tmp_screen_pgf2 => screen_coeffs_pgf(:, :, lset, kset, lkind, kkind)
+                        DO kp_idx_t = 1, nkimages
+                        DO kp_idx_q = 1, nkimages
 
-                           CALL coulomb4(private_lib, ra, rb, rc, rd, npgfa(iset), npgfb(jset), npgfc(kset), npgfd(lset), &
-                                         la_min(iset), la_max(iset), lb_min(jset), lb_max(jset), &
-                                         lc_min(kset), lc_max(kset), ld_min(lset), ld_max(lset), &
-                                         nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
-                                         sphi_a_u1, sphi_a_u2, sphi_a_u3, &
-                                         sphi_b_u1, sphi_b_u2, sphi_b_u3, &
-                                         sphi_c_u1, sphi_c_u2, sphi_c_u3, &
-                                         sphi_d_u1, sphi_d_u2, sphi_d_u3, &
-                                         zeta(1:npgfa(iset), iset), zetb(1:npgfb(jset), jset), &
-                                         zetc(1:npgfc(kset), kset), zetd(1:npgfd(lset), lset), &
-                                         primitive_integrals, &
-                                         potential_parameter, &
-                                         shm_master_x_data%neighbor_cells, screen_coeffs_set(jset, iset, jkind, ikind)%x, &
-                                         screen_coeffs_set(lset, kset, lkind, kkind)%x, eps_schwarz, &
-                                         max_contraction_val, cartesian_estimate, cell, neris_coulomb, &
-                                         log10_pmax, log10_eps_schwarz, &
-                                         tmp_R_1, tmp_R_2, tmp_screen_pgf1, tmp_screen_pgf2, &
-                                         pgf_list_ij, pgf_list_kl, pgf_product_list, &
-                                         nsgfl_a(:, iset), nsgfl_b(:, jset), &
-                                         nsgfl_c(:, kset), nsgfl_d(:, lset), &
-                                         sphi_a_ext_set, &
-                                         sphi_b_ext_set, &
-                                         sphi_c_ext_set, &
-                                         sphi_d_ext_set, &
-                                         ee_work, ee_work2, ee_buffer1, ee_buffer2, ee_primitives_tmp, &
-                                         do_periodic)
+                           !! Calculate integrals if we run out of buffer or the geometry did change
+                           IF (my_geo_change .OR. buffer_overflow) THEN
+                              max_contraction_val = max_contraction(iset, iatom)* &
+                                                    max_contraction(jset, jatom)* &
+                                                    max_contraction(kset, katom)* &
+                                                    max_contraction(lset, latom)*pmax_entry
+                              tmp_R_1 => radii_pgf(:, :, jset, iset, jkind, ikind)
+                              tmp_R_2 => radii_pgf(:, :, lset, kset, lkind, kkind)
+                              tmp_screen_pgf1 => screen_coeffs_pgf(:, :, jset, iset, jkind, ikind)
+                              tmp_screen_pgf2 => screen_coeffs_pgf(:, :, lset, kset, lkind, kkind)
 
-                           shm_neris_total = shm_neris_total + nints
-                           shm_nprim_ints = shm_nprim_ints + neris_coulomb
+                              IF (ASSOCIATED(kpoints)) THEN
+                                 CALL coulomb4(private_lib, ra, rb, rc, rd, npgfa(iset), npgfb(jset), npgfc(kset), npgfd(lset), &
+                                               la_min(iset), la_max(iset), lb_min(jset), lb_max(jset), &
+                                               lc_min(kset), lc_max(kset), ld_min(lset), ld_max(lset), &
+                                               nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
+                                               sphi_a_u1, sphi_a_u2, sphi_a_u3, &
+                                               sphi_b_u1, sphi_b_u2, sphi_b_u3, &
+                                               sphi_c_u1, sphi_c_u2, sphi_c_u3, &
+                                               sphi_d_u1, sphi_d_u2, sphi_d_u3, &
+                                               zeta(1:npgfa(iset), iset), zetb(1:npgfb(jset), jset), &
+                                               zetc(1:npgfc(kset), kset), zetd(1:npgfd(lset), lset), &
+                                               primitive_integrals, &
+                                               potential_parameter, &
+                                               shm_master_x_data%neighbor_cells, screen_coeffs_set(jset, iset, jkind, ikind)%x, &
+                                               screen_coeffs_set(lset, kset, lkind, kkind)%x, eps_schwarz, &
+                                               max_contraction_val, cartesian_estimate, cell, neris_coulomb, &
+                                               log10_pmax, log10_eps_schwarz, &
+                                               tmp_R_1, tmp_R_2, tmp_screen_pgf1, tmp_screen_pgf2, &
+                                               pgf_list_ij, pgf_list_kl, pgf_product_list, &
+                                               nsgfl_a(:, iset), nsgfl_b(:, jset), &
+                                               nsgfl_c(:, kset), nsgfl_d(:, lset), &
+                                               sphi_a_ext_set, &
+                                               sphi_b_ext_set, &
+                                               sphi_c_ext_set, &
+                                               sphi_d_ext_set, &
+                                               ee_work, ee_work2, ee_buffer1, ee_buffer2, ee_primitives_tmp, &
+                                               do_periodic, &
+                                               kpoints%index_to_cell(:, kp_idx_q), &
+                                               kpoints%index_to_cell(:, kp_idx_t))
+                              ELSE
+                                 CALL coulomb4(private_lib, ra, rb, rc, rd, npgfa(iset), npgfb(jset), npgfc(kset), npgfd(lset), &
+                                               la_min(iset), la_max(iset), lb_min(jset), lb_max(jset), &
+                                               lc_min(kset), lc_max(kset), ld_min(lset), ld_max(lset), &
+                                               nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
+                                               sphi_a_u1, sphi_a_u2, sphi_a_u3, &
+                                               sphi_b_u1, sphi_b_u2, sphi_b_u3, &
+                                               sphi_c_u1, sphi_c_u2, sphi_c_u3, &
+                                               sphi_d_u1, sphi_d_u2, sphi_d_u3, &
+                                               zeta(1:npgfa(iset), iset), zetb(1:npgfb(jset), jset), &
+                                               zetc(1:npgfc(kset), kset), zetd(1:npgfd(lset), lset), &
+                                               primitive_integrals, &
+                                               potential_parameter, &
+                                               shm_master_x_data%neighbor_cells, screen_coeffs_set(jset, iset, jkind, ikind)%x, &
+                                               screen_coeffs_set(lset, kset, lkind, kkind)%x, eps_schwarz, &
+                                               max_contraction_val, cartesian_estimate, cell, neris_coulomb, &
+                                               log10_pmax, log10_eps_schwarz, &
+                                               tmp_R_1, tmp_R_2, tmp_screen_pgf1, tmp_screen_pgf2, &
+                                               pgf_list_ij, pgf_list_kl, pgf_product_list, &
+                                               nsgfl_a(:, iset), nsgfl_b(:, jset), &
+                                               nsgfl_c(:, kset), nsgfl_d(:, lset), &
+                                               sphi_a_ext_set, &
+                                               sphi_b_ext_set, &
+                                               sphi_c_ext_set, &
+                                               sphi_d_ext_set, &
+                                               ee_work, ee_work2, ee_buffer1, ee_buffer2, ee_primitives_tmp, &
+                                               do_periodic)
+                              END IF
 
-                           !! Compress the array for storage
-                           spherical_estimate = MAX(TINY(spherical_estimate), MAXVAL(ABS(primitive_integrals(1:nints))))
+                              shm_neris_total = shm_neris_total + nints
+                              shm_nprim_ints = shm_nprim_ints + neris_coulomb
 
-                           estimate_to_store_int = EXPONENT(spherical_estimate)
-                           estimate_to_store_int = MAX(estimate_to_store_int, -15_int_8)
+                              !! Compress the array for storage
+                              spherical_estimate = MAX(TINY(spherical_estimate), MAXVAL(ABS(primitive_integrals(1:nints))))
 
-                           IF (.NOT. buffer_overflow .AND. my_geo_change) THEN
+                              estimate_to_store_int = EXPONENT(spherical_estimate)
+                              estimate_to_store_int = MAX(estimate_to_store_int, -15_int_8)
+
+                              IF (.NOT. buffer_overflow .AND. my_geo_change) THEN
+                                 IF (.NOT. use_disk_storage) THEN
+                                    CALL hfx_add_single_cache_element( &
+                                       estimate_to_store_int, 6, &
+                                       maxval_cache, maxval_container, memory_parameter%actual_memory_usage, &
+                                       .FALSE., max_val_memory)
+                                 ELSE
+                                    CALL hfx_add_single_cache_element( &
+                                       estimate_to_store_int, 6, &
+                                       maxval_cache_disk, maxval_container_disk, memory_parameter%actual_memory_usage_disk, &
+                                       .TRUE.)
+                                 END IF
+                              END IF
+
+                              spherical_estimate = SET_EXPONENT(1.0_dp, estimate_to_store_int + 1)
+                              IF (spherical_estimate*pmax_entry < eps_schwarz) CYCLE
+
+                              IF (.NOT. buffer_overflow) THEN
+                                 nbits = EXPONENT(ANINT(spherical_estimate*pmax_entry/eps_storage)) + 1
+
+                                 ! In case of a tight eps_storage threshold the number of significant
+                                 ! bits in the integer number NINT(value*pmax_entry/eps_storage) may
+                                 ! exceed the width of the storage element. As the compression algorithm
+                                 ! is designed for IEEE 754 double precision numbers, a 64-bit signed
+                                 ! integer variable which is used to store the result of this float-to-
+                                 ! integer conversion (we have no wish to use more memory for storing
+                                 ! compressed ERIs than it is needed for uncompressed ERIs) may overflow.
+                                 ! Abort with a meaningful message when it happens.
+                                 !
+                                 ! The magic number 63 stands for the number of magnitude bits
+                                 ! (64 bits minus one sign bit).
+                                 IF (nbits > 63) THEN
+                                    WRITE (eps_schwarz_min_str, '(ES10.3E2)') &
+                                       spherical_estimate*pmax_entry/ &
+                                       (SET_EXPONENT(1.0_dp, 63)*memory_parameter%eps_storage_scaling)
+
+                                    WRITE (eps_scaling_str, '(ES10.3E2)') &
+                                       spherical_estimate*pmax_entry/(SET_EXPONENT(1.0_dp, 63)*eps_schwarz)
+
+                                    CALL cp_abort(__LOCATION__, &
+                                                  "Overflow during ERI's compression. Please use a larger "// &
+                                                  "EPS_SCHWARZ threshold (above "//TRIM(ADJUSTL(eps_schwarz_min_str))// &
+                                                  ") or increase the EPS_STORAGE_SCALING factor above "// &
+                                                  TRIM(ADJUSTL(eps_scaling_str))//".")
+                                 END IF
+
+                                 buffer_left = nints
+                                 buffer_start = 1
+
+                                 IF (use_disk_storage) THEN
+                                    shm_neris_disk = shm_neris_disk + INT(nints, int_8)
+                                 ELSE
+                                    shm_neris_incore = shm_neris_incore + INT(nints, int_8)
+                                 END IF
+
+                                 DO WHILE (buffer_left > 0)
+                                    buffer_size = MIN(buffer_left, CACHE_SIZE)
+                                    IF (.NOT. use_disk_storage) THEN
+                                       CALL hfx_add_mult_cache_elements(primitive_integrals(buffer_start:), &
+                                                                        buffer_size, nbits, &
+                                                                        integral_caches(nbits), &
+                                                                        integral_containers(nbits), &
+                                                                        eps_storage, pmax_entry, &
+                                                                        memory_parameter%actual_memory_usage, &
+                                                                        .FALSE.)
+                                    ELSE
+                                       CALL hfx_add_mult_cache_elements(primitive_integrals(buffer_start:), &
+                                                                        buffer_size, nbits, &
+                                                                        integral_caches_disk(nbits), &
+                                                                        integral_containers_disk(nbits), &
+                                                                        eps_storage, pmax_entry, &
+                                                                        memory_parameter%actual_memory_usage_disk, &
+                                                                        .TRUE.)
+                                    END IF
+                                    buffer_left = buffer_left - buffer_size
+                                    buffer_start = buffer_start + buffer_size
+                                 END DO
+                              ELSE
+                                 !! In order to be consistent with in-core part, round all the eris wrt. eps_schwarz
+                                 DO i = 1, nints
+                                    primitive_integrals(i) = primitive_integrals(i)*pmax_entry
+                                    IF (ABS(primitive_integrals(i)) > eps_storage) THEN
+                                       primitive_integrals(i) = ANINT(primitive_integrals(i)/eps_storage, dp)*eps_storage/pmax_entry
+                                    ELSE
+                                       primitive_integrals(i) = 0.0_dp
+                                    END IF
+                                 END DO
+                              END IF
+
+                           ELSE  !! Get integrals from buffer instead of calculating them:
                               IF (.NOT. use_disk_storage) THEN
-                                 CALL hfx_add_single_cache_element( &
+                                 CALL hfx_get_single_cache_element( &
                                     estimate_to_store_int, 6, &
                                     maxval_cache, maxval_container, memory_parameter%actual_memory_usage, &
-                                    .FALSE., max_val_memory)
+                                    use_disk_storage)
                               ELSE
-                                 CALL hfx_add_single_cache_element( &
+                                 CALL hfx_get_single_cache_element( &
                                     estimate_to_store_int, 6, &
                                     maxval_cache_disk, maxval_container_disk, memory_parameter%actual_memory_usage_disk, &
-                                    .TRUE.)
+                                    use_disk_storage)
                               END IF
-                           END IF
-
-                           spherical_estimate = SET_EXPONENT(1.0_dp, estimate_to_store_int + 1)
-                           IF (spherical_estimate*pmax_entry < eps_schwarz) CYCLE
-
-                           IF (.NOT. buffer_overflow) THEN
+                              spherical_estimate = SET_EXPONENT(1.0_dp, estimate_to_store_int + 1)
+                              IF (spherical_estimate*pmax_entry < eps_schwarz) CYCLE
                               nbits = EXPONENT(ANINT(spherical_estimate*pmax_entry/eps_storage)) + 1
-
-                              ! In case of a tight eps_storage threshold the number of significant
-                              ! bits in the integer number NINT(value*pmax_entry/eps_storage) may
-                              ! exceed the width of the storage element. As the compression algorithm
-                              ! is designed for IEEE 754 double precision numbers, a 64-bit signed
-                              ! integer variable which is used to store the result of this float-to-
-                              ! integer conversion (we have no wish to use more memory for storing
-                              ! compressed ERIs than it is needed for uncompressed ERIs) may overflow.
-                              ! Abort with a meaningful message when it happens.
-                              !
-                              ! The magic number 63 stands for the number of magnitude bits
-                              ! (64 bits minus one sign bit).
-                              IF (nbits > 63) THEN
-                                 WRITE (eps_schwarz_min_str, '(ES10.3E2)') &
-                                    spherical_estimate*pmax_entry/ &
-                                    (SET_EXPONENT(1.0_dp, 63)*memory_parameter%eps_storage_scaling)
-
-                                 WRITE (eps_scaling_str, '(ES10.3E2)') &
-                                    spherical_estimate*pmax_entry/(SET_EXPONENT(1.0_dp, 63)*eps_schwarz)
-
-                                 CALL cp_abort(__LOCATION__, &
-                                               "Overflow during ERI's compression. Please use a larger "// &
-                                               "EPS_SCHWARZ threshold (above "//TRIM(ADJUSTL(eps_schwarz_min_str))// &
-                                               ") or increase the EPS_STORAGE_SCALING factor above "// &
-                                               TRIM(ADJUSTL(eps_scaling_str))//".")
-                              END IF
-
                               buffer_left = nints
                               buffer_start = 1
-
-                              IF (use_disk_storage) THEN
-                                 shm_neris_disk = shm_neris_disk + INT(nints, int_8)
-                              ELSE
+                              IF (.NOT. use_disk_storage) THEN
                                  shm_neris_incore = shm_neris_incore + INT(nints, int_8)
+                              ELSE
+                                 shm_neris_disk = shm_neris_disk + INT(nints, int_8)
                               END IF
-
                               DO WHILE (buffer_left > 0)
-                                 buffer_size = MIN(buffer_left, CACHE_SIZE)
+                                 buffer_size = MIN(buffer_left, cache_size)
                                  IF (.NOT. use_disk_storage) THEN
-                                    CALL hfx_add_mult_cache_elements(primitive_integrals(buffer_start:), &
+                                    CALL hfx_get_mult_cache_elements(primitive_integrals(buffer_start:), &
                                                                      buffer_size, nbits, &
                                                                      integral_caches(nbits), &
                                                                      integral_containers(nbits), &
                                                                      eps_storage, pmax_entry, &
                                                                      memory_parameter%actual_memory_usage, &
-                                                                     .FALSE.)
+                                                                     use_disk_storage)
                                  ELSE
-                                    CALL hfx_add_mult_cache_elements(primitive_integrals(buffer_start:), &
+                                    CALL hfx_get_mult_cache_elements(primitive_integrals(buffer_start:), &
                                                                      buffer_size, nbits, &
                                                                      integral_caches_disk(nbits), &
                                                                      integral_containers_disk(nbits), &
                                                                      eps_storage, pmax_entry, &
                                                                      memory_parameter%actual_memory_usage_disk, &
-                                                                     .TRUE.)
+                                                                     use_disk_storage)
                                  END IF
                                  buffer_left = buffer_left - buffer_size
                                  buffer_start = buffer_start + buffer_size
                               END DO
-                           ELSE
-                              !! In order to be consistent with in-core part, round all the eris wrt. eps_schwarz
-                              DO i = 1, nints
-                                 primitive_integrals(i) = primitive_integrals(i)*pmax_entry
-                                 IF (ABS(primitive_integrals(i)) > eps_storage) THEN
-                                    primitive_integrals(i) = ANINT(primitive_integrals(i)/eps_storage, dp)*eps_storage/pmax_entry
-                                 ELSE
-                                    primitive_integrals(i) = 0.0_dp
-                                 END IF
-                              END DO
                            END IF
 
-                        ELSE  !! Get integrals from buffer instead of calculating them:
-                           IF (.NOT. use_disk_storage) THEN
-                              CALL hfx_get_single_cache_element( &
-                                 estimate_to_store_int, 6, &
-                                 maxval_cache, maxval_container, memory_parameter%actual_memory_usage, &
-                                 use_disk_storage)
-                           ELSE
-                              CALL hfx_get_single_cache_element( &
-                                 estimate_to_store_int, 6, &
-                                 maxval_cache_disk, maxval_container_disk, memory_parameter%actual_memory_usage_disk, &
-                                 use_disk_storage)
-                           END IF
-                           spherical_estimate = SET_EXPONENT(1.0_dp, estimate_to_store_int + 1)
-                           IF (spherical_estimate*pmax_entry < eps_schwarz) CYCLE
-                           nbits = EXPONENT(ANINT(spherical_estimate*pmax_entry/eps_storage)) + 1
-                           buffer_left = nints
-                           buffer_start = 1
-                           IF (.NOT. use_disk_storage) THEN
-                              shm_neris_incore = shm_neris_incore + INT(nints, int_8)
-                           ELSE
-                              shm_neris_disk = shm_neris_disk + INT(nints, int_8)
-                           END IF
-                           DO WHILE (buffer_left > 0)
-                              buffer_size = MIN(buffer_left, cache_size)
-                              IF (.NOT. use_disk_storage) THEN
-                                 CALL hfx_get_mult_cache_elements(primitive_integrals(buffer_start:), &
-                                                                  buffer_size, nbits, &
-                                                                  integral_caches(nbits), &
-                                                                  integral_containers(nbits), &
-                                                                  eps_storage, pmax_entry, &
-                                                                  memory_parameter%actual_memory_usage, &
-                                                                  use_disk_storage)
-                              ELSE
-                                 CALL hfx_get_mult_cache_elements(primitive_integrals(buffer_start:), &
-                                                                  buffer_size, nbits, &
-                                                                  integral_caches_disk(nbits), &
-                                                                  integral_containers_disk(nbits), &
-                                                                  eps_storage, pmax_entry, &
-                                                                  memory_parameter%actual_memory_usage_disk, &
-                                                                  use_disk_storage)
-                              END IF
-                              buffer_left = buffer_left - buffer_size
-                              buffer_start = buffer_start + buffer_size
-                           END DO
-                        END IF
+                           !!!  DEBUG, print out primitive integrals and indices. Only works serial no OMP  !!!
+                           IF (.FALSE.) THEN
+                              CALL print_integrals( &
+                                 iatom, jatom, katom, latom, shm_set_offset, shm_atomic_block_offset, &
+                                 iset, jset, kset, lset, nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), primitive_integrals)
+                           ENDIF
 
-                        !!!  DEBUG, print out primitive integrals and indices. Only works serial no OMP  !!!
-                        IF (.FALSE.) THEN
-                           CALL print_integrals( &
-                              iatom, jatom, katom, latom, shm_set_offset, shm_atomic_block_offset, &
-                              iset, jset, kset, lset, nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), primitive_integrals)
-                        ENDIF
-
-                        IF (.NOT. is_anti_symmetric) THEN
-                           !! Update Kohn-Sham matrix
-                           CALL update_fock_matrix( &
-                              nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
-                              fac, symm_fac, full_density_alpha(:, 1), full_ks_alpha(:, 1), &
-                              primitive_integrals, pbd_buf, pbc_buf, pad_buf, pac_buf, kbd_buf, &
-                              kbc_buf, kad_buf, kac_buf, iatom, jatom, katom, latom, &
-                              iset, jset, kset, lset, offset_bd_set, offset_bc_set, offset_ad_set, offset_ac_set, &
-                              atomic_offset_bd, atomic_offset_bc, atomic_offset_ad, atomic_offset_ac)
-                           IF (is_unrestricted .AND. .NOT. treat_lsd_in_core) THEN
+                           IF (.NOT. is_anti_symmetric) THEN
+                              !! Update Kohn-Sham matrix
                               CALL update_fock_matrix( &
                                  nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
-                                 fac, symm_fac, full_density_beta(:, 1), full_ks_beta(:, 1), &
+                                 fac, symm_fac, full_density_alpha(:, kp_idx_q), full_ks_alpha(:, kp_idx_t), &
                                  primitive_integrals, pbd_buf, pbc_buf, pad_buf, pac_buf, kbd_buf, &
                                  kbc_buf, kad_buf, kac_buf, iatom, jatom, katom, latom, &
                                  iset, jset, kset, lset, offset_bd_set, offset_bc_set, offset_ad_set, offset_ac_set, &
                                  atomic_offset_bd, atomic_offset_bc, atomic_offset_ad, atomic_offset_ac)
-                           END IF
-                        ELSE
-                           !! Update Kohn-Sham matrix
-                           CALL update_fock_matrix_as( &
-                              nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
-                              fac, symm_fac, full_density_alpha(:, 1), full_ks_alpha(:, 1), &
-                              primitive_integrals, pbd_buf, pbc_buf, pad_buf, pac_buf, kbd_buf, &
-                              kbc_buf, kad_buf, kac_buf, iatom, jatom, katom, latom, &
-                              iset, jset, kset, lset, offset_bd_set, offset_bc_set, offset_ad_set, offset_ac_set, &
-                              atomic_offset_bd, atomic_offset_bc, atomic_offset_ad, atomic_offset_ac)
-                           IF (is_unrestricted .AND. .NOT. treat_lsd_in_core) THEN
+                              IF (is_unrestricted .AND. .NOT. treat_lsd_in_core) THEN
+                                 CALL update_fock_matrix( &
+                                    nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
+                                    fac, symm_fac, full_density_beta(:, kp_idx_q), full_ks_beta(:, kp_idx_t), &
+                                    primitive_integrals, pbd_buf, pbc_buf, pad_buf, pac_buf, kbd_buf, &
+                                    kbc_buf, kad_buf, kac_buf, iatom, jatom, katom, latom, &
+                                    iset, jset, kset, lset, offset_bd_set, offset_bc_set, offset_ad_set, offset_ac_set, &
+                                    atomic_offset_bd, atomic_offset_bc, atomic_offset_ad, atomic_offset_ac)
+                              END IF
+                           ELSE
+                              !! Update Kohn-Sham matrix
                               CALL update_fock_matrix_as( &
                                  nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
-                                 fac, symm_fac, full_density_beta(:, 1), full_ks_beta(:, 1), &
+                                 fac, symm_fac, full_density_alpha(:, kp_idx_q), full_ks_alpha(:, kp_idx_t), &
                                  primitive_integrals, pbd_buf, pbc_buf, pad_buf, pac_buf, kbd_buf, &
                                  kbc_buf, kad_buf, kac_buf, iatom, jatom, katom, latom, &
                                  iset, jset, kset, lset, offset_bd_set, offset_bc_set, offset_ad_set, offset_ac_set, &
                                  atomic_offset_bd, atomic_offset_bc, atomic_offset_ad, atomic_offset_ac)
+                              IF (is_unrestricted .AND. .NOT. treat_lsd_in_core) THEN
+                                 CALL update_fock_matrix_as( &
+                                    nsgfa(iset), nsgfb(jset), nsgfc(kset), nsgfd(lset), &
+                                    fac, symm_fac, full_density_beta(:, kp_idx_q), full_ks_beta(:, kp_idx_t), &
+                                    primitive_integrals, pbd_buf, pbc_buf, pad_buf, pac_buf, kbd_buf, &
+                                    kbc_buf, kad_buf, kac_buf, iatom, jatom, katom, latom, &
+                                    iset, jset, kset, lset, offset_bd_set, offset_bc_set, offset_ad_set, offset_ac_set, &
+                                    atomic_offset_bd, atomic_offset_bc, atomic_offset_ad, atomic_offset_ac)
+                              END IF
                            END IF
-                        END IF
+                        END DO ! kp_idx_q
+                        END DO ! kp_idx_t
                      END DO ! i_set_list_kl
                   END DO ! i_set_list_ij
 
@@ -2066,6 +2110,8 @@ CONTAINS
 !> \param ee_buffer2 ...
 !> \param ee_primitives_tmp ...
 !> \param do_periodic ...
+!> \param qcell ...
+!> \param tcell ...
 !> \par History
 !>      11.2006 created [Manuel Guidon]
 !>      02.2009 completely rewritten screening part [Manuel Guidon]
@@ -2091,7 +2137,8 @@ CONTAINS
                        nsgfl_d, &
                        sphi_a_ext, sphi_b_ext, sphi_c_ext, sphi_d_ext, &
                        ee_work, ee_work2, ee_buffer1, ee_buffer2, ee_primitives_tmp, &
-                       do_periodic)
+                       do_periodic, &
+                       qcell, tcell)
 
       TYPE(cp_libint_t)                                  :: lib
       REAL(dp), INTENT(IN)                               :: ra(3), rb(3), rc(3), rd(3)
@@ -2126,6 +2173,7 @@ CONTAINS
       REAL(dp), DIMENSION(:), INTENT(INOUT)              :: ee_work, ee_work2, ee_buffer1, &
                                                             ee_buffer2, ee_primitives_tmp
       LOGICAL, INTENT(IN)                                :: do_periodic
+      INTEGER, INTENT(IN), OPTIONAL                      :: qcell(3), tcell(3)
 
       INTEGER :: ipgf, jpgf, kpgf, la, lb, lc, ld, list_ij, list_kl, lpgf, max_l, ncoa, ncob, &
          ncoc, ncod, nelements_ij, nelements_kl, nproducts, nsgfla, nsgflb, nsgflc, nsgfld, nsoa, &
@@ -2136,6 +2184,7 @@ CONTAINS
                                pgf1, R1_pgf, log10_pmax, log10_eps_schwarz, ra, rb, &
                                nelements_ij, &
                                neighbor_cells, do_periodic)
+
       CALL build_pair_list_pgf(npgfc, npgfd, pgf_list_kl, zetc, zetd, screen2, screen1, &
                                pgf2, R2_pgf, log10_pmax, log10_eps_schwarz, rc, rd, &
                                nelements_kl, &
@@ -2157,7 +2206,7 @@ CONTAINS
 
             CALL build_pgf_product_list(pgf_list_ij(list_ij), pgf_list_kl(list_kl), pgf_product_list, &
                                         nproducts, log10_pmax, log10_eps_schwarz, neighbor_cells, cell, &
-                                        potential_parameter, max_l, do_periodic)
+                                        potential_parameter, max_l, do_periodic, tcell, qcell)
 
             s_offset_a = 0
             DO la = la_min, la_max

--- a/src/hfx_pair_list_methods.F
+++ b/src/hfx_pair_list_methods.F
@@ -1,6 +1,6 @@
 !--------------------------------------------------------------------------------------------------!
 !   CP2K: A general program to perform molecular dynamics simulations                              !
-!   Copyright 2000-2021 CP2K developers group <https://cp2k.org>                                   !
+!   Copyright 2000-2022 CP2K developers group <https://cp2k.org>                                   !
 !                                                                                                  !
 !   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
 !--------------------------------------------------------------------------------------------------!
@@ -62,10 +62,13 @@ CONTAINS
 !> \param potential_parameter potential/metric to be used
 !> \param m_max ...
 !> \param do_periodic ...
+!> \param tcell ...
+!> \param qcell ...
 ! **************************************************************************************************
    SUBROUTINE build_pgf_product_list(list1, list2, product_list, nproducts, &
                                      log10_pmax, log10_eps_schwarz, neighbor_cells, &
-                                     cell, potential_parameter, m_max, do_periodic)
+                                     cell, potential_parameter, m_max, do_periodic, &
+                                     tcell, qcell)
 
       TYPE(hfx_pgf_list), INTENT(IN)                     :: list1, list2
       TYPE(hfx_pgf_product_list), ALLOCATABLE, &
@@ -78,6 +81,7 @@ CONTAINS
       TYPE(hfx_potential_type), INTENT(IN)               :: potential_parameter
       INTEGER, INTENT(IN)                                :: m_max
       LOGICAL, INTENT(IN)                                :: do_periodic
+      INTEGER, INTENT(IN), OPTIONAL                      :: tcell(3), qcell(3)
 
       INTEGER                                            :: i, j, k, l, nimages1, nimages2, tmp_i4
       LOGICAL                                            :: use_gamma
@@ -104,7 +108,11 @@ CONTAINS
          pgf_max_1 = list1%image_list(i)%pgf_max
          ra = list1%image_list(i)%ra
          rb = list1%image_list(i)%rb
+
          DO j = 1, nimages2
+            IF (PRESENT(qcell)) THEN
+               IF (ANY(list2%image_list(j)%bcell /= (list1%image_list(i)%bcell + qcell - tcell))) CYCLE
+            END IF
             pgf_max_2 = list2%image_list(j)%pgf_max
             IF (pgf_max_1 + pgf_max_2 + log10_pmax < log10_eps_schwarz) CYCLE
             Q = list2%image_list(j)%P
@@ -128,6 +136,12 @@ CONTAINS
             END IF
 
             DO k = 1, SIZE(neighbor_cells)
+               IF (PRESENT(tcell)) THEN
+                  ! also here we only need the image for the given Fock matrix
+                  IF (ANY(neighbor_cells(k)%cell /= tcell)) &
+                     CYCLE
+               END IF
+
                IF (do_periodic) THEN
                   im_rc = rc + shift + neighbor_cells(k)%cell_r(:)
                   im_rd = rd + shift + neighbor_cells(k)%cell_r(:)
@@ -360,7 +374,6 @@ CONTAINS
       ! ** inner loop may never be reached
       nelements = npgfa*npgfb
       list(1:nelements)%nimages = 0
-
       DO i = 1, SIZE(neighbor_cells)
          IF (do_periodic) THEN
             im_B = rb + neighbor_cells(i)%cell_r(:)
@@ -403,6 +416,7 @@ CONTAINS
                   pair%ra = ra
                   pair%rb = im_B
                   pair%rab2 = rab2
+                  pair%bcell = neighbor_cells(i)%cell ! remember the coords of the neighbor_cell for this pair
 
                   pair%S1234 = (-Zeta_A*Zeta_B*ZetaInv*rab2)
                   pair%P = (Zeta_A*ra + Zeta_B*im_B)*ZetaInv

--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -1,6 +1,6 @@
 !--------------------------------------------------------------------------------------------------!
 !   CP2K: A general program to perform molecular dynamics simulations                              !
-!   Copyright 2000-2021 CP2K developers group <https://cp2k.org>                                   !
+!   Copyright 2000-2022 CP2K developers group <https://cp2k.org>                                   !
 !                                                                                                  !
 !   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
 !--------------------------------------------------------------------------------------------------!
@@ -313,6 +313,7 @@ MODULE hfx_types
       REAL(dp)                                 :: P(3)
       REAL(dp)                                 :: R
       REAL(dp)                                 :: pgf_max
+      INTEGER                                  :: bcell(3)
    END TYPE
 
 ! **************************************************************************************************


### PR DESCRIPTION
This uses a slightly different approach than the previous one. Testing with ADMM has revealed some strange behavior wrt manipulation of both the |kl> list generation and the <a|b> product list generation, hence I'm now only touching the product list generation. Swapping atom places does not change the energy anymore (which was likely caused by this), at least for a very minimal basis set. KP calculations at the Gamma point reproduce the non-kp periodic energies.
A C with 3x3x3 kp grid converges and gives somewhat reasonable values.